### PR TITLE
Fix eslintLibRe path seperators

### DIFF
--- a/no-cycles.js
+++ b/no-cycles.js
@@ -12,7 +12,7 @@ var helpers = require('./_helpers');
 
 var eslintModule = (function() {
   var parent = module.parent;
-  var eslintLibRe = /\/node_modules\/eslint\/lib\/[^/]+\.js$/;
+  var eslintLibRe = new RegExp(`\\${path.sep}node_modules\\${path.sep}eslint\\${path.sep}lib\\${path.sep}[^\\${path.sep}]+\\.js$`);
   do {
     if (eslintLibRe.test(parent.filename)) {
       return parent;


### PR DESCRIPTION
Fix for Windows filesystems.
Based on https://github.com/zertosh/eslint-plugin-dependencies/issues/4#issuecomment-248448244
